### PR TITLE
Medial Axis Interface for MPC Motion Planner

### DIFF
--- a/Functions/fcn_MedialAxis_plannerWrapper.m
+++ b/Functions/fcn_MedialAxis_plannerWrapper.m
@@ -25,7 +25,7 @@ function [route_full, route_length, route_choke] = fcn_MedialAxis_plannerWrapper
 %   without a boundary.
 %
 % min_corridor_width - double value of the narrowest corridor that should be routed through by the planner
-%
+%   setting to 0 will use all available corridors without restriction
 % length_cost_weight - scalar relative weighting of cost function, cost = w*length_cost + (1-w)*corridor width
 %   setting to 1 gives minimum distance path
 %

--- a/Functions/fcn_MedialAxis_plannerWrapper.m
+++ b/Functions/fcn_MedialAxis_plannerWrapper.m
@@ -1,0 +1,128 @@
+function [route_full, route_length, route_choke] = fcn_MedialAxis_plannerWrapper(polytope_vertices, start_xy, finish_xy, boundary_verts, min_corridor_width, length_cost_weight)
+% fcn_MedialAxis_plannerWrapper
+%
+% This function wraps the basic call stack to perform planning in thethe medial axis graph.
+% The functions called herein are called individually in script_test_voronoi_planning.m
+%
+% FORMAT:
+%
+% [route_full, route_length, route_choke] = fcn_MedialAxis_plannerWrapper(polytope_vertices, start_xy, finish_xy, boundary_verts, min_corridor_width, length_cost_weight)
+%
+%
+% INPUTS:
+% polytope_vertices - 1xP cell array where P is the number of polytopes.
+%   Each cell contains a Vx2 matrix of doubles where V is the number of vertices
+%   in a polytope.  Column 1 contains x-values and column 2 contains y-values.
+%
+% start_xy - 1x2 vector of doubles defining the (x,y) coordinates of the start position
+%
+% finish_xy - 1x2 vector of doubles defining the (x,y) coordinates of the start position
+%
+% boundary_verts - Bx2 matrix containing the (x,y) coordinates of the B-vertices forming a boundary
+%   around the polytope obstacles in the map.  The boundary does not need to contain the start or finish.
+%   The boundary is necessary as the medial axis is defined as the furthest distance from the obstacles in the
+%   domain of the free space, thus the medial axis would be infinitely far from the obstacles on the edge of the map
+%   without a boundary.
+%
+% min_corridor_width - double value of the narrowest corridor that should be routed through by the planner
+%
+% length_cost_weight - scalar relative weighting of cost function, cost = w*length_cost + (1-w)*corridor width
+%   setting to 1 gives minimum distance path
+%
+% OUTPUTS:
+%    Useful variables for outputs: R_P - number of xy points in the route.  R_N - number of nodes in the route.
+%       R_N < R_P
+%
+%    route_full: the R_Px2 series of R_P-points making up the route where the first column is the x-coordinate
+%        and the second column is the y-coordinate.
+%
+%    route_length: double representing the length of the full route from start_xy to finish_xy along
+%        the medial axis graph edges
+%
+%    route_choke: double representing the narrowest estimated corridor width along the route
+%
+%
+% DEPENDENCIES:
+%   fcn_MapGen_fillPolytopeFieldsFromVertices
+%   fcn_MedialAxis_makeAdjacencyMatrixAndTriangleChains
+%   fcn_MedialAxis_pruneGraph
+%   fcn_MedialAxis_addCostsToTriangleChains
+%   fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains
+%   fcn_MedialAxis_makeCostGraphAndAllPoints
+%   fcn_check_reachability
+%   fcn_algorithm_Astar
+%   fcn_MedialAxis_processRoute
+%
+% EXAMPLES:
+%
+% See the script: script_test_voronoi_planning_interface for an example of the script in use.
+%        script_test_voronoi_planning - shows the functions wrapped by fcn_MedialAxis_plannerWrapper in use independently
+% See ../Documentation/medial_axis_planning.pptx for a flow chart of the medial axis/voronoi planning stack
+%
+% This function was written Oct 2024 by Steve Harnett
+% Questions or comments? contact sjharnett@psu.edu
+
+%
+% REVISION HISTORY:
+%
+% 2024, Spring by Steve Harnett
+% -- first write of function
+%
+% TO DO:
+%
+% -- fill in to-do items here.
+    flag_do_plot = 0;
+
+    %% turn vertices cell array into polytopes struct array
+    clear polytopes
+    for poly = 1:length(polytope_vertices)
+        polytopes(poly).vertices = polytope_vertices{poly};
+        polytopes(poly).vertices = [polytopes(poly).vertices; polytopes(poly).vertices(1,:)]; % repeat first vert at end
+    end
+    boundary.vertices = boundary_verts;
+    boundary.vertices = [boundary.vertices; boundary.vertices(1,:)]; % repeat first vert at end
+    boundary = fcn_MapGen_fillPolytopeFieldsFromVertices(boundary); % fill polytope fields
+    shrunk_polytopes = fcn_MapGen_fillPolytopeFieldsFromVertices(polytopes);
+    shrunk_polytopes = [boundary, shrunk_polytopes]; % put the boundary polytope as the first polytope
+
+    %% assume necessary triangulation resolution
+    resolution_scale = 0.5;
+
+    %% constrained delaunay triangulation
+    [adjacency_matrix, triangle_chains, nodes, xcc, ycc, tr] = fcn_MedialAxis_makeAdjacencyMatrixAndTriangleChains(shrunk_polytopes, resolution_scale, flag_do_plot);
+
+    %% prune graph
+    [adjacency_matrix, triangle_chains, nodes] = fcn_MedialAxis_pruneGraph(adjacency_matrix, triangle_chains, nodes, xcc, ycc, shrunk_polytopes, flag_do_plot);
+
+    %% get costs for navigating each triangle chain
+    % TODO add zcc as optional input
+    [triangle_chains, max_side_lengths_per_tri] = fcn_MedialAxis_addCostsToTriangleChains(triangle_chains, nodes, xcc, ycc, tr, shrunk_polytopes, flag_do_plot);
+
+    %% planning through triangle graph
+    % add start and finish to nearest medial axis edge
+    % TODO add zcc as optional input
+    [adjacency_matrix, triangle_chains, nodes, start_closest_tri, start_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(start_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
+    [adjacency_matrix, triangle_chains, nodes, finish_closest_tri, finish_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(finish_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
+
+    % loop over cost function weights
+    denylist_route_chain_ids = []; % no need to denylist any triangle chains
+    % make cost matrix
+    [adjacency_matrix, cgraph, all_pts, start, finish, best_chain_idx_matrix] = fcn_MedialAxis_makeCostGraphAndAllPoints(adjacency_matrix, triangle_chains, nodes, xcc, ycc, start_closest_tri, start_closest_node, finish_closest_tri, finish_closest_node, length_cost_weight, min_corridor_width, denylist_route_chain_ids);
+    % adjacency matrix is vgraph
+    vgraph = adjacency_matrix;
+    num_nodes = length(nodes);
+    vgraph(1:num_nodes+1:end) = 1;
+    % check reachability
+    [is_reachable, num_steps, rgraph] = fcn_check_reachability(vgraph,start(3),finish(3));
+    if ~is_reachable
+        error('start and finish are not connected in medial axis graph')
+    end
+    % run Dijkstra's algorithm (no heuristic Astar)
+    hvec = zeros(1,num_nodes);
+
+    % plan a path
+    [cost, route] = fcn_algorithm_Astar(vgraph, cgraph, hvec, all_pts, start, finish);
+
+    % expand route nodes into actual path
+    [route_full, route_length, route_choke, route_triangle_chain, route_triangle_chain_ids] = fcn_MedialAxis_processRoute(route, triangle_chains, best_chain_idx_matrix, xcc, ycc, start_xy, finish_xy);
+end % end function

--- a/Functions/fcn_MedialAxis_replanWrapper.m
+++ b/Functions/fcn_MedialAxis_replanWrapper.m
@@ -1,28 +1,19 @@
 function [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(replan_point, finish_xy, min_corridor_width, length_cost_weight)
 % fcn_MedialAxis_replannerWrapper
 %
-% This function wraps the basic call stack to perform planning in thethe medial axis graph.
+% This function wraps the basic call stack to perform replanning in the medial axis graph.  This function would typically be called after calling fcn_MedialAxis_plannerWrapper
 % The functions called herein are called individually in script_test_voronoi_planning.m
 %
 % FORMAT:
 %
-% [route_full, route_length, route_choke] = fcn_MedialAxis_plannerWrapper(polytope_vertices, start_xy, finish_xy, boundary_verts, min_corridor_width, length_cost_weight)
+% [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(replan_point, finish_xy, min_corridor_width, length_cost_weight)
 %
 %
 % INPUTS:
-% polytope_vertices - 1xP cell array where P is the number of polytopes.
-%   Each cell contains a Vx2 matrix of doubles where V is the number of vertices
-%   in a polytope.  Column 1 contains x-values and column 2 contains y-values.
 %
-% start_xy - 1x2 vector of doubles defining the (x,y) coordinates of the start position
+% replan_point - 1x2 vector of doubles defining the (x,y) coordinates of the position from which to replan
 %
 % finish_xy - 1x2 vector of doubles defining the (x,y) coordinates of the start position
-%
-% boundary_verts - Bx2 matrix containing the (x,y) coordinates of the B-vertices forming a boundary
-%   around the polytope obstacles in the map.  The boundary does not need to contain the start or finish.
-%   The boundary is necessary as the medial axis is defined as the furthest distance from the obstacles in the
-%   domain of the free space, thus the medial axis would be infinitely far from the obstacles on the edge of the map
-%   without a boundary.
 %
 % min_corridor_width - double value of the narrowest corridor that should be routed through by the planner
 %   setting to 0 will use all available corridors without restriction
@@ -56,7 +47,7 @@ function [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(
 % EXAMPLES:
 %
 % See the script: script_test_voronoi_planning_interface for an example of the script in use.
-%        script_test_voronoi_planning - shows the functions wrapped by fcn_MedialAxis_plannerWrapper in use independently
+%        script_test_voronoi_planning - shows the functions wrapped by fcn_MedialAxis_replanWrapper in use independently
 % See ../Documentation/medial_axis_planning.pptx for a flow chart of the medial axis/voronoi planning stack
 %
 % This function was written Oct 2024 by Steve Harnett

--- a/Functions/fcn_MedialAxis_replanWrapper.m
+++ b/Functions/fcn_MedialAxis_replanWrapper.m
@@ -78,6 +78,8 @@ function [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(
         error('Medial axis graph is not created yet.  Please call fcn_MedialAxis_plannerWrapper before calling fcn_MedialAxis_replanWrapper.')
     end
 
+    global denylist_route_chain_ids
+
     adjacency_matrix = medial_axis_graph.adjacency_matrix;
     triangle_chains = medial_axis_graph.triangle_chains;
     max_side_lengths_per_tri = medial_axis_graph.max_side_lengths_per_tri;
@@ -111,7 +113,11 @@ function [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(
     edge_that_will_fail = find([triangle_chains{:,1}]' == replanning_node & [triangle_chains{:,2}]' == unreached_node);
     % edge_that_will_fail_bw = find([triangle_chains{:,2}]' == replanning_node & [triangle_chains{:,1}]' == unreached_node);
     % denylist_route_chain_ids = [edge_that_failed, edge_that_will_fail, edge_that_failed_bw, edge_that_will_fail_bw]
-    denylist_route_chain_ids = [edge_that_failed, edge_that_will_fail];
+    if isempty(denylist_route_chain_ids)
+        denylist_route_chain_ids = [edge_that_failed, edge_that_will_fail];
+    else
+        denylist_route_chain_ids = [denylist_route_chain_ids, edge_that_failed, edge_that_will_fail];
+    end
 
     [adjacency_matrix, triangle_chains, nodes, finish_closest_tri, finish_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(finish_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
     % loop over cost function weights
@@ -135,4 +141,11 @@ function [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(
 
     % expand route nodes into actual path
     [route_full, route_length, route_choke, route_triangle_chain, route_triangle_chain_ids] = fcn_MedialAxis_processRoute(route, triangle_chains, best_chain_idx_matrix, xcc, ycc, start_xy, finish_xy);
+
+    % set globals:
+    medial_axis_graph.route = route;
+    medial_axis_graph.route_triangle_chain = route_triangle_chain;
+    medial_axis_graph.route_triangle_chain_ids = route_triangle_chain_ids;
+
+
 end % end function

--- a/Functions/fcn_MedialAxis_replanWrapper.m
+++ b/Functions/fcn_MedialAxis_replanWrapper.m
@@ -111,7 +111,7 @@ function [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(
     edge_that_will_fail = find([triangle_chains{:,1}]' == replanning_node & [triangle_chains{:,2}]' == unreached_node);
     % edge_that_will_fail_bw = find([triangle_chains{:,2}]' == replanning_node & [triangle_chains{:,1}]' == unreached_node);
     % denylist_route_chain_ids = [edge_that_failed, edge_that_will_fail, edge_that_failed_bw, edge_that_will_fail_bw]
-    denylist_route_chain_ids = [edge_that_failed, edge_that_will_fail]
+    denylist_route_chain_ids = [edge_that_failed, edge_that_will_fail];
 
     [adjacency_matrix, triangle_chains, nodes, finish_closest_tri, finish_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(finish_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
     % loop over cost function weights

--- a/Functions/fcn_MedialAxis_replanWrapper.m
+++ b/Functions/fcn_MedialAxis_replanWrapper.m
@@ -1,5 +1,5 @@
-function [route_full, route_length, route_choke, medial_axis_graph] = fcn_MedialAxis_plannerWrapper(polytope_vertices, start_xy, finish_xy, boundary_verts, min_corridor_width, length_cost_weight)
-% fcn_MedialAxis_plannerWrapper
+[route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(replan_point, finish, min_corridor_width, length_cost_weight);
+% fcn_MedialAxis_replannerWrapper
 %
 % This function wraps the basic call stack to perform planning in thethe medial axis graph.
 % The functions called herein are called individually in script_test_voronoi_planning.m
@@ -108,14 +108,7 @@ function [route_full, route_length, route_choke, medial_axis_graph] = fcn_Medial
     denylist_route_chain_ids = []; % no need to denylist any triangle chains
     % make cost matrix
     [adjacency_matrix, cgraph, all_pts, start, finish, best_chain_idx_matrix] = fcn_MedialAxis_makeCostGraphAndAllPoints(adjacency_matrix, triangle_chains, nodes, xcc, ycc, start_closest_tri, start_closest_node, finish_closest_tri, finish_closest_node, length_cost_weight, min_corridor_width, denylist_route_chain_ids);
-    % TODO struct for memory of graph, probably also needs cost information?
-    medial_axis_graph.adjacency_matrix = adjacency_matrixj;
-    medial_axis_graph.triangle_chains = triangle_chains;
-    medial_axis_graph.nodes = nodes;
-    medial_axis_graph.xcc = xcc;
-    medial_axis_graph.ycc = ycc;
-    medial_axis_graph.tr = tr;
-       %% adjacency matrix is vgraph
+    % adjacency matrix is vgraph
     vgraph = adjacency_matrix;
     num_nodes = length(nodes);
     vgraph(1:num_nodes+1:end) = 1;
@@ -133,3 +126,4 @@ function [route_full, route_length, route_choke, medial_axis_graph] = fcn_Medial
     % expand route nodes into actual path
     [route_full, route_length, route_choke, route_triangle_chain, route_triangle_chain_ids] = fcn_MedialAxis_processRoute(route, triangle_chains, best_chain_idx_matrix, xcc, ycc, start_xy, finish_xy);
 end % end function
+

--- a/Functions/fcn_MedialAxis_replanWrapper.m
+++ b/Functions/fcn_MedialAxis_replanWrapper.m
@@ -1,4 +1,4 @@
-function [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(replan_point, finish_xy, min_corridor_width, length_cost_weight);
+function [route_full, route_length, route_choke] = fcn_MedialAxis_replanWrapper(replan_point, finish_xy, min_corridor_width, length_cost_weight)
 % fcn_MedialAxis_replannerWrapper
 %
 % This function wraps the basic call stack to perform planning in thethe medial axis graph.

--- a/Functions/script_test_voronoi_planning_interface.m
+++ b/Functions/script_test_voronoi_planning_interface.m
@@ -45,3 +45,6 @@ plot(route(:,1), route(:,2), '-k','LineWidth',2.5) % plot approx. medial axis
 xlabel('x [m]')
 ylabel('y [m]')
 title(sprintf('path length: %.2f [m]\n narrowest corridor: %.2f [m]',route_length, route_choke));
+
+replan_point = [2, 2.5];
+[route, route_length, route_choke] = fcn_MedialAxis_replanWrapper(replan_point, finish, min_corridor_width, length_cost_weight);

--- a/Functions/script_test_voronoi_planning_interface.m
+++ b/Functions/script_test_voronoi_planning_interface.m
@@ -1,0 +1,162 @@
+% script_test_voronoi_planning_interface
+% test script of planning along voronoi diagram edges via a wrapper function that encompases the
+% medial axis planning stack
+clear; close all; clc
+
+addpath(strcat(pwd,'\..\..\PathPlanning_PathTools_PathClassLibrary\Functions'));
+addpath(strcat(pwd,'\..\..\PathPlanning_MapTools_MapGenClassLibrary\Functions'));
+addpath(strcat(pwd,'\..\..\Errata_Tutorials_DebugTools\Functions'));
+
+
+map_idx = 7;
+flag_do_plot = 1;
+flag_do_animation = 0;
+flag_do_plot_slow = 0;
+[shrunk_polytopes, start_init, finish_init, resolution_scale] = fcn_util_load_test_map(map_idx, 1);
+
+%% for sake of comparisons, do this with a visibility graph as well
+polytopes = shrunk_polytopes;
+if flag_do_plot
+    fig = 99; % figure to plot on
+    line_spec = 'b-'; % edge line plotting
+    line_width = 2; % linewidth of the edge
+    axes_limits = [1025 1055 -4726 -4710]; % x and y axes limits
+    axis_style = 'square'; % plot axes style
+    fcn_plot_polytopes(polytopes(2:end),fig,line_spec,line_width,axes_limits,axis_style);
+    hold on
+    box on
+    xlabel('x [km]')
+    ylabel('y [km]')
+end
+point_tot = length([polytopes.xv]); % total number of vertices in the convex polytopes
+beg_end = zeros(1,point_tot); % is the point the start/end of an obstacle
+curpt = 0;
+for poly = 1:size(polytopes,2) % check each polytope
+    verts = unique(polytopes(poly).vertices,'stable','rows');
+    num_verts = size(verts,1);
+    polytopes(poly).obs_id = ones(1,num_verts)*poly; % obs_id is the same for every vertex on a single polytope
+    polytopes(poly).xv = verts(:,1)';
+    polytopes(poly).yv = verts(:,2)';
+    polytopes(poly).vertices = [verts; verts(1,:)];
+    polytopes(poly).distances = fcn_general_calculation_euclidean_point_to_point_distance(polytopes(poly).vertices(1:end-1,:),polytopes(poly).vertices(2:end,:));
+    beg_end([curpt+1,curpt+num_verts]) = 1; % the first and last vertices are marked with 1 and all others are 0
+    curpt = curpt+num_verts;
+    polytopes(poly).perimeter = sum(polytopes(poly).distances);
+end
+obs_id = [polytopes.obs_id];
+point_tot = length([polytopes.xv]); % need to recheck total points
+beg_end = beg_end(1:point_tot); % remove any extra points
+all_pts = [[polytopes.xv];[polytopes.yv];1:point_tot;obs_id;beg_end]'; % all points [x y point_id obs_id beg_end]
+vgraph_times = [];
+for i = 1:10 % get timing data for repeat iterations
+    create_vgraph_timer = tic;
+    [vgraph, visibility_results] = fcn_visibility_clear_and_blocked_points_global(polytopes,all_pts,all_pts);
+    vgraph_time = toc(create_vgraph_timer)
+    vgraph_times = [vgraph_times vgraph_time]
+end
+% plot visibility graph edges
+if flag_do_plot
+    for i = 1:size(vgraph,1)
+        for j = 1:size(vgraph,1)
+            if vgraph(i,j) == 1
+                plot([all_pts(i,1),all_pts(j,1)],[all_pts(i,2),all_pts(j,2)],'-r')
+            end
+        end
+    end
+end
+med_ax_times = [];
+for i = 1:10 % get timing data for repeat iterations
+    t_medial_axis = tic;
+    %% constrained delaunay triangulation
+    [adjacency_matrix, triangle_chains, nodes, xcc, ycc, tr] = fcn_MedialAxis_makeAdjacencyMatrixAndTriangleChains(shrunk_polytopes, resolution_scale, flag_do_plot);
+    medial_axis_time = toc(t_medial_axis)
+    med_ax_times = [med_ax_times medial_axis_time]
+end
+
+%% prune graph
+[adjacency_matrix, triangle_chains, nodes] = fcn_MedialAxis_pruneGraph(adjacency_matrix, triangle_chains, nodes, xcc, ycc, shrunk_polytopes, flag_do_plot);
+
+%% get costs for navigating each triangle chain
+% TODO add zcc as optional input
+[triangle_chains, max_side_lengths_per_tri] = fcn_MedialAxis_addCostsToTriangleChains(triangle_chains, nodes, xcc, ycc, tr, shrunk_polytopes, flag_do_plot);
+
+%% planning through triangle graph
+start_xy = start_init;
+finish_xy = finish_init;
+% add start and finish to nearest medial axis edge
+% TODO add zcc as optional input
+[adjacency_matrix, triangle_chains, nodes, start_closest_tri, start_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(start_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
+[adjacency_matrix, triangle_chains, nodes, finish_closest_tri, finish_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(finish_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
+
+% loop over cost function weights
+for w = 0.1:0.1:1
+    min_corridor_width = 0; % do not restrict corridor width
+    denylist_route_chain_ids = []; % no need to denylist any triangle chains
+    % make cost matrix
+    [adjacency_matrix, cgraph, all_pts, start, finish, best_chain_idx_matrix] = fcn_MedialAxis_makeCostGraphAndAllPoints(adjacency_matrix, triangle_chains, nodes, xcc, ycc, start_closest_tri, start_closest_node, finish_closest_tri, finish_closest_node, w, min_corridor_width, denylist_route_chain_ids);
+    % adjacency matrix is vgraph
+    vgraph = adjacency_matrix;
+    num_nodes = length(nodes);
+    vgraph(1:num_nodes+1:end) = 1;
+    % check reachability
+    [is_reachable, num_steps, rgraph] = fcn_check_reachability(vgraph,start(3),finish(3));
+    if ~is_reachable
+        error('initial mission, prior to edge deletion, is not possible')
+    end
+    % run Dijkstra's algorithm (no heuristic)
+    hvec = zeros(1,num_nodes);
+
+    % plan a path
+    [cost, route] = fcn_algorithm_Astar(vgraph, cgraph, hvec, all_pts, start, finish);
+
+    % expand route nodes into actual path
+    [route_full, route_length, route_choke, route_triangle_chain, route_triangle_chain_ids] = fcn_MedialAxis_processRoute(route, triangle_chains, best_chain_idx_matrix, xcc, ycc, start_xy, finish_xy);
+    % plot result
+    figure; hold on; box on;
+    xlabel('x [km]');
+    ylabel('y [km]');
+    leg_str = {};
+    leg_str{end+1} = 'medial axis graph';
+    not_first = 0;
+    % plot all triangle chains
+    for i = 1:(size(triangle_chains,1))
+        % pop off a triangle chain
+        chain_of_note = triangle_chains{i,3};
+        if isempty(chain_of_note)
+            continue
+        end
+        % plot big markers for the start and end node
+        beg_end = [chain_of_note(1) chain_of_note(end)];
+        % plot a straight line between them (this is the adjacency graph connection)
+        plot(xcc(beg_end), ycc(beg_end), '--.','MarkerSize',20,'Color',0.6*ones(1,3));
+        if not_first
+            leg_str{end+1} = '';
+        end
+        not_first =1;
+        % plot the medial axis path between them (this is the curved path from the triangle chain)
+        plot(xcc(chain_of_note), ycc(chain_of_note), '--','LineWidth',2,'Color',0.6*ones(1,3));
+        leg_str{end+1} = '';
+    end
+    plot(start_xy(1),start_xy(2),'xg','MarkerSize',10);
+    plot(finish_xy(1),finish_xy(2),'xr','MarkerSize',10);
+    plot(start(1),start(2),'.g','MarkerSize',10);
+    plot(finish(1),finish(2),'.r','MarkerSize',10);
+    leg_str{end+1} = 'start';
+    leg_str{end+1} = 'finish';
+    leg_str{end+1} = 'start node';
+    leg_str{end+1} = 'finish node';
+    plot(route(:,1),route(:,2),'--r','MarkerSize',20,'LineWidth',1);
+    leg_str{end+1} = sprintf('adjacency of route nodes');
+    for j = 2:length(shrunk_polytopes)
+        fill(shrunk_polytopes(j).vertices(:,1)',shrunk_polytopes(j).vertices(:,2),[0 0 1],'FaceAlpha',0.3)
+    end
+    leg_str{end+1} = 'obstacles';
+    for i = 1:length(shrunk_polytopes)-2
+        leg_str{end+1} = '';
+    end
+    plot(route_full(:,1), route_full(:,2), '-k','LineWidth',2.5) % plot approx. medial axis
+    leg_str{end+1} = 'medial axis route';
+    legend(leg_str,'Location','best');
+    tit_str = sprintf('length cost weight was: %.1f \n total length: %.2f km \n worst corridor: %.2f km',w, route_length, route_choke);
+    title(tit_str)
+end % end weight loop

--- a/Functions/script_test_voronoi_planning_interface.m
+++ b/Functions/script_test_voronoi_planning_interface.m
@@ -12,16 +12,16 @@ addpath(strcat(pwd,'\..\..\Errata_Tutorials_DebugTools\Functions'));
 n_polys = 16; % number of polytopes
 polytope_vertices = cell(1,n_polys); % initialize empty cell array
 rng(10); % set rng seed for determinism
-num_verts = randi([3 3],n_polys); % random integer for num. verts of each poly, between 3 and 10
-poly_scale = ones(1,n_polys); % random vector of scale factors between 0 and 3 for polytope size
+% random integer for num. verts of each poly, currently set between 3 and 3 to make triangles
+num_verts = randi([3 3],n_polys);
+poly_scale = ones(1,n_polys); % vector to scale size of polytopes if desired, currently set to 1
 figure; hold on; box on;
 for poly = 1:n_polys
     verts = rand(num_verts(poly),2); % create random nx2 matrix of vertices
-    verts = verts - 0.5; % center random dist. at 0
-    verts = verts*poly_scale(poly);
-    [x_shift, y_shift] = ind2sub([4, 4], poly);
+    verts = verts - 0.5; % center random verts at 0
+    verts = verts*poly_scale(poly); % scale size of polytopes
+    [x_shift, y_shift] = ind2sub([4, 4], poly); % shift polytope to position in 4x4 obs. field
     verts = verts + [x_shift*ones(num_verts(poly),1) y_shift*ones(num_verts(poly),1)]; % shift vertices based on position in matrix
-    verts = [verts; verts(1,:)]; % repeat first vertex at end
     fill(verts(:,1),verts(:,2),poly_scale(poly));
     polytope_vertices{poly} = verts;
 end
@@ -33,117 +33,12 @@ boundary_verts = [0.25 0.25;...
                   0.25 4.75;...
                   4.75 4.75;...
                   4.75 0.25;...
-                  0.25 0.25];
+                  ];
 min_corridor_width = 0;
 length_cost_weight = 1;
 
-% TODO functional interface should begin here
-fcn_MedialAxis_plannerWrapper(polytope_vertices, start, finish, boundary_verts, min_corridor_width, length_cost_weight)
-function fcn_MedialAxis_plannerWrapper(polytope_vertices, start, finish, boundary_verts, min_corridor_width, length_cost_weight)
-flag_do_plot = 1;
-flag_do_animation = 0;
-flag_do_plot_slow = 0;
-
-clear polytopes
-for poly = 1:length(polytope_vertices)
-    polytopes(poly).vertices = polytope_vertices{poly};
-end
-boundary.vertices = boundary_verts;
-boundary = fcn_MapGen_fillPolytopeFieldsFromVertices(boundary); % fill polytope fields
-shrunk_polytopes = fcn_MapGen_fillPolytopeFieldsFromVertices(polytopes);
-shrunk_polytopes = [boundary, shrunk_polytopes]; % put the boundary polytope as the first polytope
-
-fig_num = 2;
-line_width = 3;
-fcn_MapGen_plotPolytopes(polytopes,fig_num,'r-',line_width);
-
-resolution_scale = 0.5;
-%% constrained delaunay triangulation
-[adjacency_matrix, triangle_chains, nodes, xcc, ycc, tr] = fcn_MedialAxis_makeAdjacencyMatrixAndTriangleChains(shrunk_polytopes, resolution_scale, flag_do_plot);
-
-%% prune graph
-[adjacency_matrix, triangle_chains, nodes] = fcn_MedialAxis_pruneGraph(adjacency_matrix, triangle_chains, nodes, xcc, ycc, shrunk_polytopes, flag_do_plot);
-
-%% get costs for navigating each triangle chain
-% TODO add zcc as optional input
-[triangle_chains, max_side_lengths_per_tri] = fcn_MedialAxis_addCostsToTriangleChains(triangle_chains, nodes, xcc, ycc, tr, shrunk_polytopes, flag_do_plot);
-
-%% planning through triangle graph
-start_xy = start;
-finish_xy = finish;
-% add start and finish to nearest medial axis edge
-% TODO add zcc as optional input
-[adjacency_matrix, triangle_chains, nodes, start_closest_tri, start_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(start_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
-[adjacency_matrix, triangle_chains, nodes, finish_closest_tri, finish_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(finish_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
-
-% loop over cost function weights
-w = length_cost_weight;
-denylist_route_chain_ids = []; % no need to denylist any triangle chains
-% make cost matrix
-[adjacency_matrix, cgraph, all_pts, start, finish, best_chain_idx_matrix] = fcn_MedialAxis_makeCostGraphAndAllPoints(adjacency_matrix, triangle_chains, nodes, xcc, ycc, start_closest_tri, start_closest_node, finish_closest_tri, finish_closest_node, w, min_corridor_width, denylist_route_chain_ids);
-% adjacency matrix is vgraph
-vgraph = adjacency_matrix;
-num_nodes = length(nodes);
-vgraph(1:num_nodes+1:end) = 1;
-% check reachability
-[is_reachable, num_steps, rgraph] = fcn_check_reachability(vgraph,start(3),finish(3));
-if ~is_reachable
-    error('initial mission, prior to edge deletion, is not possible')
-end
-% run Dijkstra's algorithm (no heuristic)
-hvec = zeros(1,num_nodes);
-
-% plan a path
-[cost, route] = fcn_algorithm_Astar(vgraph, cgraph, hvec, all_pts, start, finish);
-
-% expand route nodes into actual path
-[route_full, route_length, route_choke, route_triangle_chain, route_triangle_chain_ids] = fcn_MedialAxis_processRoute(route, triangle_chains, best_chain_idx_matrix, xcc, ycc, start_xy, finish_xy);
-% plot result
-figure; hold on; box on;
-xlabel('x [km]');
-ylabel('y [km]');
-leg_str = {};
-leg_str{end+1} = 'medial axis graph';
-not_first = 0;
-% plot all triangle chains
-for i = 1:(size(triangle_chains,1))
-    % pop off a triangle chain
-    chain_of_note = triangle_chains{i,3};
-    if isempty(chain_of_note)
-        continue
-    end
-    % plot big markers for the start and end node
-    beg_end = [chain_of_note(1) chain_of_note(end)];
-    % plot a straight line between them (this is the adjacency graph connection)
-    plot(xcc(beg_end), ycc(beg_end), '--.','MarkerSize',20,'Color',0.6*ones(1,3));
-    if not_first
-        leg_str{end+1} = '';
-    end
-    not_first =1;
-    % plot the medial axis path between them (this is the curved path from the triangle chain)
-    plot(xcc(chain_of_note), ycc(chain_of_note), '--','LineWidth',2,'Color',0.6*ones(1,3));
-    leg_str{end+1} = '';
-end
-plot(start_xy(1),start_xy(2),'xg','MarkerSize',10);
-plot(finish_xy(1),finish_xy(2),'xr','MarkerSize',10);
-plot(start(1),start(2),'.g','MarkerSize',10);
-plot(finish(1),finish(2),'.r','MarkerSize',10);
-leg_str{end+1} = 'start';
-leg_str{end+1} = 'finish';
-leg_str{end+1} = 'start node';
-leg_str{end+1} = 'finish node';
-plot(route(:,1),route(:,2),'--r','MarkerSize',20,'LineWidth',1);
-leg_str{end+1} = sprintf('adjacency of route nodes');
-for j = 2:length(shrunk_polytopes)
-    fill(shrunk_polytopes(j).vertices(:,1)',shrunk_polytopes(j).vertices(:,2),[0 0 1],'FaceAlpha',0.3)
-end
-leg_str{end+1} = 'obstacles';
-for i = 1:length(shrunk_polytopes)-2
-    leg_str{end+1} = '';
-end
-plot(route_full(:,1), route_full(:,2), '-k','LineWidth',2.5) % plot approx. medial axis
-leg_str{end+1} = 'medial axis route';
-legend(leg_str,'Location','best');
-tit_str = sprintf('length cost weight was: %.1f \n total length: %.2f km \n worst corridor: %.2f km',w, route_length, route_choke);
-title(tit_str)
-end % end weight loop
+%% wrapper function called here
+route = fcn_MedialAxis_plannerWrapper(polytope_vertices, start, finish, boundary_verts, min_corridor_width, length_cost_weight);
+%% plot result
+figure(1);
+plot(route(:,1), route(:,2), '-k','LineWidth',2.5) % plot approx. medial axis

--- a/Functions/script_test_voronoi_planning_interface.m
+++ b/Functions/script_test_voronoi_planning_interface.m
@@ -51,3 +51,8 @@ replan_point = [2, 2.5];
 [new_route,~ ,~] = fcn_MedialAxis_replanWrapper(replan_point, finish, min_corridor_width, length_cost_weight);
 plot(replan_point(1), replan_point(2), 'dm','MarkerFaceColor','m','MarkerSize',6)
 plot(new_route(:,1), new_route(:,2), '--g','LineWidth',2.5)
+
+replan_point = [1.5, 3];
+[new_route,~ ,~] = fcn_MedialAxis_replanWrapper(replan_point, finish, min_corridor_width, length_cost_weight);
+plot(replan_point(1), replan_point(2), 'dr','MarkerFaceColor','r','MarkerSize',6)
+plot(new_route(:,1), new_route(:,2), '--r','LineWidth',2.5)

--- a/Functions/script_test_voronoi_planning_interface.m
+++ b/Functions/script_test_voronoi_planning_interface.m
@@ -38,7 +38,10 @@ min_corridor_width = 0;
 length_cost_weight = 1;
 
 %% wrapper function called here
-route = fcn_MedialAxis_plannerWrapper(polytope_vertices, start, finish, boundary_verts, min_corridor_width, length_cost_weight);
+[route, route_length, route_choke] = fcn_MedialAxis_plannerWrapper(polytope_vertices, start, finish, boundary_verts, min_corridor_width, length_cost_weight);
 %% plot result
 figure(1);
 plot(route(:,1), route(:,2), '-k','LineWidth',2.5) % plot approx. medial axis
+xlabel('x [m]')
+ylabel('y [m]')
+title(sprintf('path length: %.2f [m]\n narrowest corridor: %.2f [m]',route_length, route_choke));

--- a/Functions/script_test_voronoi_planning_interface.m
+++ b/Functions/script_test_voronoi_planning_interface.m
@@ -35,16 +35,19 @@ boundary_verts = [0.25 0.25;...
                   4.75 0.25;...
                   ];
 min_corridor_width = 0;
+
 length_cost_weight = 1;
 
 %% wrapper function called here
 [route, route_length, route_choke] = fcn_MedialAxis_plannerWrapper(polytope_vertices, start, finish, boundary_verts, min_corridor_width, length_cost_weight);
 %% plot result
 figure(1);
-plot(route(:,1), route(:,2), '-k','LineWidth',2.5) % plot approx. medial axis
+plot(route(:,1), route(:,2), '-k','LineWidth',2.5)
 xlabel('x [m]')
 ylabel('y [m]')
 title(sprintf('path length: %.2f [m]\n narrowest corridor: %.2f [m]',route_length, route_choke));
 
 replan_point = [2, 2.5];
-[route, route_length, route_choke] = fcn_MedialAxis_replanWrapper(replan_point, finish, min_corridor_width, length_cost_weight);
+[new_route,~ ,~] = fcn_MedialAxis_replanWrapper(replan_point, finish, min_corridor_width, length_cost_weight);
+plot(replan_point(1), replan_point(2), 'dm','MarkerFaceColor','m','MarkerSize',6)
+plot(new_route(:,1), new_route(:,2), '--g','LineWidth',2.5)

--- a/Functions/script_test_voronoi_planning_interface.m
+++ b/Functions/script_test_voronoi_planning_interface.m
@@ -3,75 +3,63 @@
 % medial axis planning stack
 clear; close all; clc
 
+%% declair dependencies
 addpath(strcat(pwd,'\..\..\PathPlanning_PathTools_PathClassLibrary\Functions'));
 addpath(strcat(pwd,'\..\..\PathPlanning_MapTools_MapGenClassLibrary\Functions'));
 addpath(strcat(pwd,'\..\..\Errata_Tutorials_DebugTools\Functions'));
 
+%% polytopes for testing
+n_polys = 16; % number of polytopes
+polytope_vertices = cell(1,n_polys); % initialize empty cell array
+rng(10); % set rng seed for determinism
+num_verts = randi([3 3],n_polys); % random integer for num. verts of each poly, between 3 and 10
+poly_scale = ones(1,n_polys); % random vector of scale factors between 0 and 3 for polytope size
+figure; hold on; box on;
+for poly = 1:n_polys
+    verts = rand(num_verts(poly),2); % create random nx2 matrix of vertices
+    verts = verts - 0.5; % center random dist. at 0
+    verts = verts*poly_scale(poly);
+    [x_shift, y_shift] = ind2sub([4, 4], poly);
+    verts = verts + [x_shift*ones(num_verts(poly),1) y_shift*ones(num_verts(poly),1)]; % shift vertices based on position in matrix
+    verts = [verts; verts(1,:)]; % repeat first vertex at end
+    fill(verts(:,1),verts(:,2),poly_scale(poly));
+    polytope_vertices{poly} = verts;
+end
 
-map_idx = 7;
+%% other inputs for testing
+start = [0.5 0.5];
+finish = [4.5 4.5];
+boundary_verts = [0.25 0.25;...
+                  0.25 4.75;...
+                  4.75 4.75;...
+                  4.75 0.25;...
+                  0.25 0.25];
+min_corridor_width = 0;
+length_cost_weight = 1;
+
+% TODO functional interface should begin here
+fcn_MedialAxis_plannerWrapper(polytope_vertices, start, finish, boundary_verts, min_corridor_width, length_cost_weight)
+function fcn_MedialAxis_plannerWrapper(polytope_vertices, start, finish, boundary_verts, min_corridor_width, length_cost_weight)
 flag_do_plot = 1;
 flag_do_animation = 0;
 flag_do_plot_slow = 0;
-[shrunk_polytopes, start_init, finish_init, resolution_scale] = fcn_util_load_test_map(map_idx, 1);
 
-%% for sake of comparisons, do this with a visibility graph as well
-polytopes = shrunk_polytopes;
-if flag_do_plot
-    fig = 99; % figure to plot on
-    line_spec = 'b-'; % edge line plotting
-    line_width = 2; % linewidth of the edge
-    axes_limits = [1025 1055 -4726 -4710]; % x and y axes limits
-    axis_style = 'square'; % plot axes style
-    fcn_plot_polytopes(polytopes(2:end),fig,line_spec,line_width,axes_limits,axis_style);
-    hold on
-    box on
-    xlabel('x [km]')
-    ylabel('y [km]')
+clear polytopes
+for poly = 1:length(polytope_vertices)
+    polytopes(poly).vertices = polytope_vertices{poly};
 end
-point_tot = length([polytopes.xv]); % total number of vertices in the convex polytopes
-beg_end = zeros(1,point_tot); % is the point the start/end of an obstacle
-curpt = 0;
-for poly = 1:size(polytopes,2) % check each polytope
-    verts = unique(polytopes(poly).vertices,'stable','rows');
-    num_verts = size(verts,1);
-    polytopes(poly).obs_id = ones(1,num_verts)*poly; % obs_id is the same for every vertex on a single polytope
-    polytopes(poly).xv = verts(:,1)';
-    polytopes(poly).yv = verts(:,2)';
-    polytopes(poly).vertices = [verts; verts(1,:)];
-    polytopes(poly).distances = fcn_general_calculation_euclidean_point_to_point_distance(polytopes(poly).vertices(1:end-1,:),polytopes(poly).vertices(2:end,:));
-    beg_end([curpt+1,curpt+num_verts]) = 1; % the first and last vertices are marked with 1 and all others are 0
-    curpt = curpt+num_verts;
-    polytopes(poly).perimeter = sum(polytopes(poly).distances);
-end
-obs_id = [polytopes.obs_id];
-point_tot = length([polytopes.xv]); % need to recheck total points
-beg_end = beg_end(1:point_tot); % remove any extra points
-all_pts = [[polytopes.xv];[polytopes.yv];1:point_tot;obs_id;beg_end]'; % all points [x y point_id obs_id beg_end]
-vgraph_times = [];
-for i = 1:10 % get timing data for repeat iterations
-    create_vgraph_timer = tic;
-    [vgraph, visibility_results] = fcn_visibility_clear_and_blocked_points_global(polytopes,all_pts,all_pts);
-    vgraph_time = toc(create_vgraph_timer)
-    vgraph_times = [vgraph_times vgraph_time]
-end
-% plot visibility graph edges
-if flag_do_plot
-    for i = 1:size(vgraph,1)
-        for j = 1:size(vgraph,1)
-            if vgraph(i,j) == 1
-                plot([all_pts(i,1),all_pts(j,1)],[all_pts(i,2),all_pts(j,2)],'-r')
-            end
-        end
-    end
-end
-med_ax_times = [];
-for i = 1:10 % get timing data for repeat iterations
-    t_medial_axis = tic;
-    %% constrained delaunay triangulation
-    [adjacency_matrix, triangle_chains, nodes, xcc, ycc, tr] = fcn_MedialAxis_makeAdjacencyMatrixAndTriangleChains(shrunk_polytopes, resolution_scale, flag_do_plot);
-    medial_axis_time = toc(t_medial_axis)
-    med_ax_times = [med_ax_times medial_axis_time]
-end
+boundary.vertices = boundary_verts;
+boundary = fcn_MapGen_fillPolytopeFieldsFromVertices(boundary); % fill polytope fields
+shrunk_polytopes = fcn_MapGen_fillPolytopeFieldsFromVertices(polytopes);
+shrunk_polytopes = [boundary, shrunk_polytopes]; % put the boundary polytope as the first polytope
+
+fig_num = 2;
+line_width = 3;
+fcn_MapGen_plotPolytopes(polytopes,fig_num,'r-',line_width);
+
+resolution_scale = 0.5;
+%% constrained delaunay triangulation
+[adjacency_matrix, triangle_chains, nodes, xcc, ycc, tr] = fcn_MedialAxis_makeAdjacencyMatrixAndTriangleChains(shrunk_polytopes, resolution_scale, flag_do_plot);
 
 %% prune graph
 [adjacency_matrix, triangle_chains, nodes] = fcn_MedialAxis_pruneGraph(adjacency_matrix, triangle_chains, nodes, xcc, ycc, shrunk_polytopes, flag_do_plot);
@@ -81,82 +69,81 @@ end
 [triangle_chains, max_side_lengths_per_tri] = fcn_MedialAxis_addCostsToTriangleChains(triangle_chains, nodes, xcc, ycc, tr, shrunk_polytopes, flag_do_plot);
 
 %% planning through triangle graph
-start_xy = start_init;
-finish_xy = finish_init;
+start_xy = start;
+finish_xy = finish;
 % add start and finish to nearest medial axis edge
 % TODO add zcc as optional input
 [adjacency_matrix, triangle_chains, nodes, start_closest_tri, start_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(start_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
 [adjacency_matrix, triangle_chains, nodes, finish_closest_tri, finish_closest_node] = fcn_MedialAxis_addPointToAdjacencyMatrixAndTriangleChains(finish_xy, adjacency_matrix, triangle_chains, nodes, xcc, ycc, max_side_lengths_per_tri);
 
 % loop over cost function weights
-for w = 0.1:0.1:1
-    min_corridor_width = 0; % do not restrict corridor width
-    denylist_route_chain_ids = []; % no need to denylist any triangle chains
-    % make cost matrix
-    [adjacency_matrix, cgraph, all_pts, start, finish, best_chain_idx_matrix] = fcn_MedialAxis_makeCostGraphAndAllPoints(adjacency_matrix, triangle_chains, nodes, xcc, ycc, start_closest_tri, start_closest_node, finish_closest_tri, finish_closest_node, w, min_corridor_width, denylist_route_chain_ids);
-    % adjacency matrix is vgraph
-    vgraph = adjacency_matrix;
-    num_nodes = length(nodes);
-    vgraph(1:num_nodes+1:end) = 1;
-    % check reachability
-    [is_reachable, num_steps, rgraph] = fcn_check_reachability(vgraph,start(3),finish(3));
-    if ~is_reachable
-        error('initial mission, prior to edge deletion, is not possible')
+w = length_cost_weight;
+denylist_route_chain_ids = []; % no need to denylist any triangle chains
+% make cost matrix
+[adjacency_matrix, cgraph, all_pts, start, finish, best_chain_idx_matrix] = fcn_MedialAxis_makeCostGraphAndAllPoints(adjacency_matrix, triangle_chains, nodes, xcc, ycc, start_closest_tri, start_closest_node, finish_closest_tri, finish_closest_node, w, min_corridor_width, denylist_route_chain_ids);
+% adjacency matrix is vgraph
+vgraph = adjacency_matrix;
+num_nodes = length(nodes);
+vgraph(1:num_nodes+1:end) = 1;
+% check reachability
+[is_reachable, num_steps, rgraph] = fcn_check_reachability(vgraph,start(3),finish(3));
+if ~is_reachable
+    error('initial mission, prior to edge deletion, is not possible')
+end
+% run Dijkstra's algorithm (no heuristic)
+hvec = zeros(1,num_nodes);
+
+% plan a path
+[cost, route] = fcn_algorithm_Astar(vgraph, cgraph, hvec, all_pts, start, finish);
+
+% expand route nodes into actual path
+[route_full, route_length, route_choke, route_triangle_chain, route_triangle_chain_ids] = fcn_MedialAxis_processRoute(route, triangle_chains, best_chain_idx_matrix, xcc, ycc, start_xy, finish_xy);
+% plot result
+figure; hold on; box on;
+xlabel('x [km]');
+ylabel('y [km]');
+leg_str = {};
+leg_str{end+1} = 'medial axis graph';
+not_first = 0;
+% plot all triangle chains
+for i = 1:(size(triangle_chains,1))
+    % pop off a triangle chain
+    chain_of_note = triangle_chains{i,3};
+    if isempty(chain_of_note)
+        continue
     end
-    % run Dijkstra's algorithm (no heuristic)
-    hvec = zeros(1,num_nodes);
-
-    % plan a path
-    [cost, route] = fcn_algorithm_Astar(vgraph, cgraph, hvec, all_pts, start, finish);
-
-    % expand route nodes into actual path
-    [route_full, route_length, route_choke, route_triangle_chain, route_triangle_chain_ids] = fcn_MedialAxis_processRoute(route, triangle_chains, best_chain_idx_matrix, xcc, ycc, start_xy, finish_xy);
-    % plot result
-    figure; hold on; box on;
-    xlabel('x [km]');
-    ylabel('y [km]');
-    leg_str = {};
-    leg_str{end+1} = 'medial axis graph';
-    not_first = 0;
-    % plot all triangle chains
-    for i = 1:(size(triangle_chains,1))
-        % pop off a triangle chain
-        chain_of_note = triangle_chains{i,3};
-        if isempty(chain_of_note)
-            continue
-        end
-        % plot big markers for the start and end node
-        beg_end = [chain_of_note(1) chain_of_note(end)];
-        % plot a straight line between them (this is the adjacency graph connection)
-        plot(xcc(beg_end), ycc(beg_end), '--.','MarkerSize',20,'Color',0.6*ones(1,3));
-        if not_first
-            leg_str{end+1} = '';
-        end
-        not_first =1;
-        % plot the medial axis path between them (this is the curved path from the triangle chain)
-        plot(xcc(chain_of_note), ycc(chain_of_note), '--','LineWidth',2,'Color',0.6*ones(1,3));
+    % plot big markers for the start and end node
+    beg_end = [chain_of_note(1) chain_of_note(end)];
+    % plot a straight line between them (this is the adjacency graph connection)
+    plot(xcc(beg_end), ycc(beg_end), '--.','MarkerSize',20,'Color',0.6*ones(1,3));
+    if not_first
         leg_str{end+1} = '';
     end
-    plot(start_xy(1),start_xy(2),'xg','MarkerSize',10);
-    plot(finish_xy(1),finish_xy(2),'xr','MarkerSize',10);
-    plot(start(1),start(2),'.g','MarkerSize',10);
-    plot(finish(1),finish(2),'.r','MarkerSize',10);
-    leg_str{end+1} = 'start';
-    leg_str{end+1} = 'finish';
-    leg_str{end+1} = 'start node';
-    leg_str{end+1} = 'finish node';
-    plot(route(:,1),route(:,2),'--r','MarkerSize',20,'LineWidth',1);
-    leg_str{end+1} = sprintf('adjacency of route nodes');
-    for j = 2:length(shrunk_polytopes)
-        fill(shrunk_polytopes(j).vertices(:,1)',shrunk_polytopes(j).vertices(:,2),[0 0 1],'FaceAlpha',0.3)
-    end
-    leg_str{end+1} = 'obstacles';
-    for i = 1:length(shrunk_polytopes)-2
-        leg_str{end+1} = '';
-    end
-    plot(route_full(:,1), route_full(:,2), '-k','LineWidth',2.5) % plot approx. medial axis
-    leg_str{end+1} = 'medial axis route';
-    legend(leg_str,'Location','best');
-    tit_str = sprintf('length cost weight was: %.1f \n total length: %.2f km \n worst corridor: %.2f km',w, route_length, route_choke);
-    title(tit_str)
+    not_first =1;
+    % plot the medial axis path between them (this is the curved path from the triangle chain)
+    plot(xcc(chain_of_note), ycc(chain_of_note), '--','LineWidth',2,'Color',0.6*ones(1,3));
+    leg_str{end+1} = '';
+end
+plot(start_xy(1),start_xy(2),'xg','MarkerSize',10);
+plot(finish_xy(1),finish_xy(2),'xr','MarkerSize',10);
+plot(start(1),start(2),'.g','MarkerSize',10);
+plot(finish(1),finish(2),'.r','MarkerSize',10);
+leg_str{end+1} = 'start';
+leg_str{end+1} = 'finish';
+leg_str{end+1} = 'start node';
+leg_str{end+1} = 'finish node';
+plot(route(:,1),route(:,2),'--r','MarkerSize',20,'LineWidth',1);
+leg_str{end+1} = sprintf('adjacency of route nodes');
+for j = 2:length(shrunk_polytopes)
+    fill(shrunk_polytopes(j).vertices(:,1)',shrunk_polytopes(j).vertices(:,2),[0 0 1],'FaceAlpha',0.3)
+end
+leg_str{end+1} = 'obstacles';
+for i = 1:length(shrunk_polytopes)-2
+    leg_str{end+1} = '';
+end
+plot(route_full(:,1), route_full(:,2), '-k','LineWidth',2.5) % plot approx. medial axis
+leg_str{end+1} = 'medial axis route';
+legend(leg_str,'Location','best');
+tit_str = sprintf('length cost weight was: %.1f \n total length: %.2f km \n worst corridor: %.2f km',w, route_length, route_choke);
+title(tit_str)
 end % end weight loop


### PR DESCRIPTION
This PR adds a simple wrapper function, `fcn_MedialAxis_plannerWrapper`, for the call stack required to perform medial axis graph planning, which was implemented in #8.  As implemented in #8, the call stack was represented by several separate functions.  This PR allows those functions to be called by a single wrapper function that uses primitive data types for i/o so the wrapped can be [called from Python using the Matlab engine](https://www.mathworks.com/help/matlab/matlab-engine-for-python.html). The wrapper contains nearly identical code to what is demonstrated in `script_test_voronoi_planning.m`.  All plotting is disabled to improve performance.  The flow chart of the call stack is in : [Documentation/medial_axis_planning.pptx](https://github.com/ivsg-psu/PathPlanning_GridFreePathPlanners_BoundedAStar/blob/main/Documentation/medial_axis_planning.pptx). The chart is reproduced here:
![349243965-f751f176-d333-4f09-b2f3-0d02a0b95ceb](https://github.com/user-attachments/assets/b6f1492d-6ec5-4aca-b00c-ecab63f1e62f)
Planning using this wrapper is demonstrated in the test script `script_test_voronoi_planning_interface.m` which produces the following result:
![map](https://github.com/user-attachments/assets/c82dcc45-184d-45f2-a36f-d15117ff7b59)
